### PR TITLE
Fix memory leak in FormBase.SetWindowRegion

### DIFF
--- a/FormBase.cs
+++ b/FormBase.cs
@@ -115,7 +115,8 @@ namespace BorderlessForm
 
         private void SetWindowRegion(IntPtr hwnd, int left, int top, int right, int bottom)
         {
-            var hrg = new HandleRef((object)this, NativeMethods.CreateRectRgn(0, 0, 0, 0));
+            var rgn = NativeMethods.CreateRectRgn(0, 0, 0, 0);
+            var hrg = new HandleRef((object)this, rgn);
             var r = NativeMethods.GetWindowRgn(hwnd, hrg.Handle);
             RECT box;
             NativeMethods.GetRgnBox(hrg.Handle, out box);
@@ -124,6 +125,7 @@ namespace BorderlessForm
                 var hr = new HandleRef((object)this, NativeMethods.CreateRectRgn(left, top, right, bottom));
                 NativeMethods.SetWindowRgn(hwnd, hr.Handle, NativeMethods.IsWindowVisible(hwnd));
             }
+            NativeMethods.DeleteObject(rgn);
         }
 
         public FormWindowState MinMaxState

--- a/Native.cs
+++ b/Native.cs
@@ -368,6 +368,9 @@ namespace BorderlessForm
 
         [DllImport("shell32.dll")]
         public static extern int SHAppBarMessage(uint dwMessage, [In] ref APPBARDATA pData);
+
+        [DllImport("gdi32.dll")]
+        public static extern bool DeleteObject(IntPtr hObj);
     }
 
     public static class NativeConstants


### PR DESCRIPTION
The region created in FormBase.SetWindowRegion needs to be deleted afterwards.

Once you hit around 10k calls without cleaning up (20s of moving the window around) we're out of memory.

Video:
https://www.youtube.com/watch?v=yAlFNrrKXVA